### PR TITLE
Migration to Play 2.5

### DIFF
--- a/examples/play-scala/build.sbt
+++ b/examples/play-scala/build.sbt
@@ -2,15 +2,29 @@ name := "play-scala-example"
 
 version := "1.0-SNAPSHOT"
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala)
+lazy val root = (project in file("."))
+  .settings(conflictManager := ConflictManager.latestCompatible)
+  .settings(dependencyOverrides := Set(
+    "org.scala-lang"              % "scala-library"             % "2.11.7",
+    "org.scala-lang"              % "scala-reflect"             % "2.11.7",
+    "org.scala-lang.modules"      %% "scala-xml"                % "1.0.1",
+    "org.scala-lang.modules"      %% "scala-parser-combinators" % "1.0.4",
+    "com.google.guava"            % "guava"                     % "19.0",
+    "com.fasterxml.jackson.core"  % "jackson-core"              % "2.7.3",
+    "com.fasterxml.jackson.core"  % "jackson-annotations"       % "2.7.3",
+    "com.fasterxml.jackson.core"  % "jackson-databind"          % "2.7.3",
+
+    "org.specs2"                  %% "specs2-core"              % "3.7.3"
+  ))
+  .enablePlugins(PlayScala)
 
 scalaVersion := "2.11.7"
 
 resolvers += "Scalaz Bintray Repo" at "https://dl.bintray.com/scalaz/releases"
 
 libraryDependencies ++= Seq(
-  "de.leanovate.swaggercheck" %% "swagger-check-core" % "0.99.1" % Test,
-  "org.specs2" %% "specs2-scalacheck" % "3.6" % Test,
+  "de.leanovate.swaggercheck" %% "swagger-check-core" % "0.99.3" % Test,
+  "org.specs2" %% "specs2-scalacheck" % "3.7.3" % Test,
   specs2 % Test
 )
 

--- a/examples/play-scala/project/build.properties
+++ b/examples/play-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.11

--- a/examples/play-scala/project/plugins.sbt
+++ b/examples/play-scala/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.3")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.1")

--- a/examples/play-scala/test/controllers/ThingsControllerSpec.scala
+++ b/examples/play-scala/test/controllers/ThingsControllerSpec.scala
@@ -22,15 +22,16 @@ class ThingsControllerSpec extends PlaySpecification with ScalaCheck with ThingA
   "ThingController" should {
     "support all /things routes" in {
       implicit val arbitraryRequest = Arbitrary[PlayOperationVerifier](swaggerCheck.operationVerifier())
+      val app = testApp()
 
       prop {
         requestVerifier: PlayOperationVerifier =>
-          val Some(result) = route(requestVerifier.request)
+          val Some(result) = route(app, requestVerifier.request)
 
           status(result) must between(200, 300)
 
           requestVerifier.responseVerifier.verify(result) must be equalTo ValidationResult.success
-      }.setContext(new WithApplication(testApp()) {})
+      }
     }
   }
 

--- a/json-schema-jackson/build.sbt
+++ b/json-schema-jackson/build.sbt
@@ -6,5 +6,5 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-annotations" % Common.jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-core" % Common.jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-databind" % Common.jacksonVersion,
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.5.3"
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % Common.jacksonVersion
 )

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,4 +1,3 @@
-
 import sbt.Keys._
 import sbt._
 import sbtrelease.ReleasePlugin.autoImport._
@@ -8,9 +7,9 @@ import xerial.sbt.Sonatype.SonatypeKeys._
 object Common {
   val scalaCheckVersion = "1.13.0"
 
-  val jacksonVersion = "2.5.4"
+  val jacksonVersion = "2.7.3"
 
-  val playVersion = "2.4.3"
+  val playVersion = "2.5.1"
 
   val settings = Seq(
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.11

--- a/swagger-check-core/build.sbt
+++ b/swagger-check-core/build.sbt
@@ -5,11 +5,11 @@ Common.settings
 libraryDependencies ++= Seq(
   "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
   "org.scalacheck" %% "scalacheck" % Common.scalaCheckVersion,
-  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.5.4",
-  "com.fasterxml.jackson.core" % "jackson-core" % "2.5.4",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.5.4",
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.5.3",
-  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % "2.4.5",
+  "com.fasterxml.jackson.core" % "jackson-annotations" % Common.jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-core" % Common.jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-databind" % Common.jacksonVersion,
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % Common.jacksonVersion,
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Common.jacksonVersion,
   "com.typesafe.play" %% "play-test" % Common.playVersion % "provided",
   "org.scala-lang" % "scala-reflect" % scalaVersion.value
 )

--- a/swagger-check-core/src/test/scala/de/leanovate/swaggercheck/playhelper/FutureResultsSpec.scala
+++ b/swagger-check-core/src/test/scala/de/leanovate/swaggercheck/playhelper/FutureResultsSpec.scala
@@ -15,8 +15,7 @@ class FutureResultsSpec extends WordSpec with MustMatchers {
       FutureResults.responseExtractor.body(futureResult) mustBe "{}"
       FutureResults.responseExtractor.headers(futureResult) mustBe Map(
         "some" -> "header",
-        "something" -> "else",
-        "Content-Type" -> "text/plain; charset=utf-8")
+        "something" -> "else")
     }
   }
 }


### PR DESCRIPTION
I would like to use leanovate/swagger-check in Play 2.5-based project. Current version of swagger-check (99.2) isn't compatible with Play 2.5, so I've updated dependencies and example project. Would you be so kind to review and release new version?
