### PR TITLE
Replaced `Gen.choose` with `Arbitrary.arbitrary`

### DIFF
--- a/json-schema-gen/src/main/scala/de/leanovate/swaggercheck/schema/gen/formats/GeneratableIntegerFormats.scala
+++ b/json-schema-gen/src/main/scala/de/leanovate/swaggercheck/schema/gen/formats/GeneratableIntegerFormats.scala
@@ -2,19 +2,19 @@ package de.leanovate.swaggercheck.schema.gen.formats
 
 import de.leanovate.swaggercheck.schema.model.formats.IntegerFormats
 import de.leanovate.swaggercheck.schema.model.{JsonPath, ValidationResult}
-import org.scalacheck.Gen
+import org.scalacheck.{Arbitrary, Gen}
 
 object GeneratableIntegerFormats {
 
   object Int32 extends GeneratableFormat[BigInt] {
-    override def generate: Gen[BigInt] = Gen.choose(Int.MinValue, Int.MaxValue).map(BigInt.apply)
+    override def generate: Gen[BigInt] = Arbitrary.arbitrary[Int].map(BigInt.apply)
 
     override def validate(path: JsonPath, value: BigInt): ValidationResult =
       IntegerFormats.Int32.validate(path, value)
   }
 
   object Int64 extends GeneratableFormat[BigInt] {
-    override def generate: Gen[BigInt] = Gen.choose(Long.MinValue, Long.MaxValue).map(BigInt.apply)
+    override def generate: Gen[BigInt] = Arbitrary.arbitrary[Long].map(BigInt.apply)
 
     override def validate(path: JsonPath, value: BigInt): ValidationResult =
       IntegerFormats.Int64.validate(path, value)


### PR DESCRIPTION
`Gen.choose` replaced with proper scala-chek `Arbitrary.arbitrary` within `GeneratableIntegerFormats`. 

It should be safe cause this is how `Double` and `Float` generators are obtained in `GeneratableNumberFormats`.
